### PR TITLE
Show login error message if credentials are wrong

### DIFF
--- a/src/Page/Login.elm
+++ b/src/Page/Login.elm
@@ -187,7 +187,8 @@ validate =
 
 errorsDecoder : Decoder (List String)
 errorsDecoder =
-    decode (\email username password -> List.concat [ email, username, password ])
+        decode (\emailOrPassword email username password -> List.concat [ emailOrPassword, email, username, password ])
+        |> optionalError "email or password"
         |> optionalError "email"
         |> optionalError "username"
         |> optionalError "password"


### PR DESCRIPTION
Pull request contains a fix addressing the issue that currently no error message is displayed if the user tries to login with wrong credentials. #4 

This will handle the server response:
```json
{"errors":{"email or password":["is invalid"]}}
```
and render:
![image](https://cloud.githubusercontent.com/assets/13085980/25874823/a6fd00b0-3514-11e7-94e8-0052508c3613.png)
