### PR TITLE
Reroute root url to the empty hash url

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -284,6 +284,9 @@ setRoute maybeRoute model =
             Just Route.Home ->
                 transition HomeLoaded (Home.init model.session)
 
+            Just Route.Root ->
+                model => Route.modifyUrl Route.Home
+
             Just Route.Login ->
                 { model | pageState = Loaded (Login Login.initialModel) } => Cmd.none
 

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -13,6 +13,7 @@ import Data.User as User exposing (Username)
 
 type Route
     = Home
+    | Root
     | Login
     | Logout
     | Register
@@ -48,6 +49,9 @@ routeToString page =
         pieces =
             case page of
                 Home ->
+                    []
+
+                Root ->
                     []
 
                 Login ->
@@ -94,6 +98,6 @@ modifyUrl =
 fromLocation : Location -> Maybe Route
 fromLocation location =
     if String.isEmpty location.hash then
-        Just Home
+        Just Root
     else
         parseHash route location


### PR DESCRIPTION
The existing demo.realworld.io site and the angular/react demos all modify the root url to include the "#/" on a root page load. This accomplishes that.