### PR TITLE
bug: fix variable decoder `updatedAt`

### DIFF
--- a/src/Data/User.elm
+++ b/src/Data/User.elm
@@ -47,7 +47,7 @@ encode user =
         , "bio" => EncodeExtra.maybe Encode.string user.bio
         , "image" => UserPhoto.encode user.image
         , "createdAt" => Encode.string user.createdAt
-        , "updatedAt" => Encode.string user.createdAt
+        , "updatedAt" => Encode.string user.updatedAt
         ]
 
 


### PR DESCRIPTION
Looks like there is a typo in the encoder pipeline that should have been `updatedAt` instead of `createdAt`.