### PR TITLE
Use uglifyjs `--no-rename` flag to compress and mangle in one step with `pure_funcs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ This [generates production-optimized JS](https://elm-lang.org/blog/small-assets-
 
 #### Step 2
 
-(Make sure you have [Uglify](http://lisperator.net/uglifyjs/) installed first, e.g. with `npm install --global uglify-js`)
+(Make sure you have [Uglify](https://github.com/mishoo/UglifyJS2) installed first, e.g. with `npm install --global uglify-js`)
 
 ```
-$ uglifyjs elm.js --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters=true,keep_fargs=false,unsafe_comps=true,unsafe=true,passes=2' --output=elm.js && uglifyjs elm.js --mangle --output=elm.js
+$ uglifyjs elm.js --no-rename --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters=true,keep_fargs=false,unsafe_comps=true,unsafe=true,passes=2' --mangle --output=elm.js
 ```
 
-This one lengthy command (make sure to scroll horizontally to get all of it if you're copy/pasting!) runs `uglifyjs` twice - first with `--compress` and then again with `--mangle`.
+This is a lengthy command - make sure to scroll horizontally to get all of it if you're copy/pasting!
 
-> It's necessay to run Uglify twice if you use the `pure_funcs` flag, because if you enable both `--compress` and `--mangle` at the same time, the `pure_funcs` argument will have no effect; Uglify will mangle the names first and then not recognize them when it encounters those functions later.
+It's neccessary to disable the internal Uglify `rename` pass with `--no-rename` when you use the `pure_funcs` flag, because if you enable both `--compress` and `--mangle` at the same time, the `pure_funcs` argument will have no effect; Uglify will rename symbols first and then not recognize them when it encounters those functions later.

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ $ uglifyjs elm.js --no-rename --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2
 
 This is a lengthy command - make sure to scroll horizontally to get all of it if you're copy/pasting!
 
-It's neccessary to disable the internal Uglify `rename` pass with `--no-rename` when you use the `pure_funcs` flag, because if you enable both `--compress` and `--mangle` at the same time, the `pure_funcs` argument will have no effect; Uglify will rename symbols first and then not recognize them when it encounters those functions later.
+It's neccessary to disable the internal Uglify `rename` pass with `--no-rename` when you use the `pure_funcs` flag, because if you enable both `--compress` and `--mangle` at the same time, the `pure_funcs` argument will have no effect; Uglify will rename symbols first and then not recognize them when it encounters them later.

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ $ uglifyjs elm.js --no-rename --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2
 
 This is a lengthy command - make sure to scroll horizontally to get all of it if you're copy/pasting!
 
-It's neccessary to disable the internal Uglify `rename` pass with `--no-rename` when you use the `pure_funcs` flag, because if you enable both `--compress` and `--mangle` at the same time, the `pure_funcs` argument will have no effect; Uglify will rename symbols first and then not recognize them when it encounters them later.
+It's neccessary to disable the internal Uglify `rename` pass with `--no-rename` when you use the `pure_funcs` flag, because if you enable both `--compress` and `--mangle` at the same time, the `pure_funcs` argument will have no effect; Uglify will rename symbols first and then not recognize them when encountered later.


### PR DESCRIPTION
```
$ uglifyjs elm.js --no-rename --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters=true,keep_fargs=false,unsafe_comps=true,unsafe=true,passes=2' --mangle --output=elm.js
```

It's neccessary to disable the internal Uglify `rename` pass with `--no-rename` when you use the `pure_funcs` flag, because if you enable both `--compress` and `--mangle` at the same time, the `pure_funcs` argument will have no effect; Uglify will rename symbols first and then not recognize them when encountered later. Using two uglify commands works of course, but it invokes the parser twice which makes it a bit slower.

Doc update assumes the use of `uglify-js@3.x`.

The lesser known internal Uglify `rename` pass runs before `compress` and should not be confused with `mangle` which runs after `compress`.