### PR TITLE
Add viewport meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Conduit</title>
 
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png">


### PR DESCRIPTION
This PR makes it look nice on mobile.

Before on mobile:

<img width="412" alt="before" src="https://user-images.githubusercontent.com/7637655/47262330-984c7600-d49a-11e8-9c8f-678fa91a2642.png">

After on mobile:

<img width="413" alt="after" src="https://user-images.githubusercontent.com/7637655/47262329-984c7600-d49a-11e8-9021-4282c951d947.png">

After on mobile 2:

<img width="410" alt="after-bottom" src="https://user-images.githubusercontent.com/7637655/47262328-97b3df80-d49a-11e8-8331-f666431f1bab.png">

