### PR TITLE
Send the parsed stringified JSON to Elm in localStorate event listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
       // Whenever localStorage changes in another tab, report it if necessary.
       window.addEventListener("storage", function(event) {
         if (event.storageArea === localStorage && event.key === storageKey) {
-          app.ports.onStoreChange.send(event.newValue);
+          app.ports.onStoreChange.send(JSON.parse(event.newValue));
         }
       }, false);
     </script>


### PR DESCRIPTION
The `event.newValue` contains the stringified version of the `store`. In order to send the same value as in line 38, we need to parse it before sending it.