### PR TITLE
Be explicit on logout sending a null value

### DIFF
--- a/src/Api.elm
+++ b/src/Api.elm
@@ -109,15 +109,15 @@ storeCredWith (Cred uname token) avatar =
                   )
                 ]
     in
-    storeCache (Just json)
+    storeCache json
 
 
 logout : Cmd msg
 logout =
-    storeCache Nothing
+    storeCache Encode.null
 
 
-port storeCache : Maybe Value -> Cmd msg
+port storeCache : Value -> Cmd msg
 
 
 


### PR DESCRIPTION
Instead of sending a Maybe value we send explicitly a `Encode.null` value in the `logout` function. 

The main reason I am proposing this is that [SimulatedEffect.Ports.send](https://package.elm-lang.org/packages/avh4/elm-program-test/latest/SimulatedEffect-Ports#send) takes always a `Decode.Value` so its easier to test this.

It's also not preferred as said in the official elm docs 

> Sending Json.Decode.Value through ports is recommended, but not the only way