### PR TITLE
Add Gitpod Config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+                    
+USER gitpod
+
+RUN npm install -g elm elm-test elm-format

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+ - init: elm make src/Main.elm --output elm.js --debug
+   command: python3 -m http.server
+ports:
+ - port: 8000
+   onOpen: open-preview
+vscode:
+  extensions:
+    - elmTooling.elm-ls-vscode@0.8.0:rb3k4mPelyC4Fqod9UBvvA==

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ to explain the principles I used to build this. I highly recommend watching it!
 > [Elm](http://elm-lang.org) codebase containing real world examples (CRUD, auth, advanced patterns, etc) that adheres to the [RealWorld](https://github.com/gothinkster/realworld-example-apps) spec and API.
 
 
-### [Demo](https://elm-spa-example.netlify.com/)&nbsp;&nbsp;&nbsp;&nbsp;[RealWorld](https://github.com/gothinkster/realworld)
+### [Demo](https://elm-spa-example.netlify.com/)&nbsp;&nbsp;&nbsp;&nbsp;[RealWorld](https://github.com/gothinkster/realworld)&nbsp;&nbsp;&nbsp;&nbsp;[Dev Environment](https://gitpod.io/#https://github.com/rtfeldman/elm-spa-example) 
 
 
 This codebase was created to demonstrate a fully fledged fullstack application built with [Elm](http://elm-lang.org) including CRUD operations, authentication, routing, pagination, and more.
@@ -15,7 +15,7 @@ For more information on how this works with other frontends/backends, head over 
 
 # How it works
 
-Check out [the full writeup](https://dev.to/rtfeldman/tour-of-an-open-source-elm-spa)!
+Check out [the full writeup](https://dev.to/rtfeldman/tour-of-an-open-source-elm-spa)! 
 
 # Building
 


### PR DESCRIPTION
Hi Richard,
this PR proposes a dev environment config, which allows anyone interested in Elm to get started with one click. The gitpod service is free for open-source and I have configured it to have the required tools installed, build the project including and launch a web server, so users can immediately see the result. It also includes the latest version of the Elm VS Code extension.

You can try it out using this link:

https://gitpod.io/#https://github.com/svenefftinge/elm-spa-example

Let me know what you think.

<img width="1439" alt="Screenshot 2020-02-09 at 15 24 55" src="https://user-images.githubusercontent.com/372735/74103920-58f2de80-4b50-11ea-9be4-a87ffa7f4450.png">
