### PR TITLE
Changed the uglify --output parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This [generates production-optimized JS](https://elm-lang.org/blog/small-assets-
 (Make sure you have [Uglify](http://lisperator.net/uglifyjs/) installed first, e.g. with `npm install --global uglify-js`)
 
 ```
-$ uglifyjs elm.js --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters=true,keep_fargs=false,unsafe_comps=true,unsafe=true,passes=2' --output=elm.js && uglifyjs elm.js --mangle --output=elm.js
+$ uglifyjs elm.js --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters=true,keep_fargs=false,unsafe_comps=true,unsafe=true,passes=2' --output elm.js && uglifyjs elm.js --mangle --output elm.js
 ```
 
 This one lengthy command (make sure to scroll horizontally to get all of it if you're copy/pasting!) runs `uglifyjs` twice - first with `--compress` and then again with `--mangle`.


### PR DESCRIPTION
The uglifyjs --output parameter gave an "ERROR: invalid option --output=elm.js"

This commit changes the instructions to say --output elm.js in two relevant places

Attempts to fix https://github.com/rtfeldman/elm-spa-example/issues/98